### PR TITLE
Updates composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,16 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": "^7.1.3",
         "illuminate/database": "5.6.*",
-        "illuminate/filesystem": "5.6.*",
-        "illuminate/validation": "^5.6",
+        "illuminate/validation": "5.6.*",
         "laravel-zero/framework": "5.6.*",
         "open-resource-manager/client-php": "~1.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
1. Use semver caret operator.
2. Removes `illuminate/filesystem` because is already included by the framework.
3. Bumps php version to `^7.1.3` because is required by Symfony itself.